### PR TITLE
Fix for Firefox "change" event with keyboard use

### DIFF
--- a/customSelect.jquery.js
+++ b/customSelect.jquery.js
@@ -30,7 +30,7 @@
 						customSelectInnerSpan.css({width:selectBoxWidth, display:'inline-block'});
 						var selectBoxHeight = customSelectSpan.outerHeight();
 						$this.css({'-webkit-appearance':'menulist-button',width:customSelectSpan.outerWidth(),position:'absolute', opacity:0,height:selectBoxHeight,fontSize:customSelectSpan.css('font-size')});
-					}).change(function(){
+					}).bind("change keyup",function(){
 						var currentSelected = $this.find(':selected');
 						var html = currentSelected.html() || '&nbsp;';
 						customSelectInnerSpan.html(html).parent().addClass('customSelectChanged');


### PR DESCRIPTION
Fixes keyboard interaction with the select box in Firefox - unlike other browsers, FF doesn't fire "change" event until the select element loses focus, meaning the span display wasn't updating properly. By adding a "keyup" event in addition to the change event, this limitation is bypassed and the plugin works for keyboard users in FF.
