### PR TITLE
Adding support for disabled option element used as a placeholder

### DIFF
--- a/jquery.customSelect.js
+++ b/jquery.customSelect.js
@@ -28,6 +28,8 @@
                     setTimeout(function () {
                         customSelectSpan.removeClass('customSelectOpen');
                         $(document).off('mouseup.customSelectOpen');
+                        if (currentSelected.attr('disabled')) { customSelectSpan.addClass('customSelectPlaceholder'); }
+                        else { customSelectSpan.removeClass('customSelectPlaceholder'); }                        
                     }, 60);
                 };
 


### PR DESCRIPTION
Adding a CSS class called "customSelectPlaceholder" which will be applied to the customSelect &lt;span&gt; if the currently selected &lt;option&gt; element is disabled. Since from the user perspective you can't select a disabled option, this is only useful if the disabled &lt;option&gt;  was already selected during the loading of the form and is used as a kind of placeholder.
