### PR TITLE
move class change outside of timeout

### DIFF
--- a/jquery.customSelect.js
+++ b/jquery.customSelect.js
@@ -28,6 +28,8 @@
                     setTimeout(function () {
                         customSelectSpan.removeClass('customSelectOpen');
                         $(document).off('mouseup.customSelectOpen');
+                        if (currentSelected.attr('disabled')) { customSelectSpan.addClass('customSelectPlaceholder'); }
+                        else { customSelectSpan.removeClass('customSelectPlaceholder'); }                        
                     }, 60);
                 };
 

--- a/jquery.customSelect.js
+++ b/jquery.customSelect.js
@@ -28,8 +28,8 @@
                     setTimeout(function () {
                         customSelectSpan.removeClass('customSelectOpen');
                         $(document).off('mouseup.customSelectOpen');
-                        if (currentSelected.attr('disabled')) { customSelectSpan.addClass('customSelectPlaceholder'); }
-                        else { customSelectSpan.removeClass('customSelectPlaceholder'); }                        
+                        if (currentSelected.attr('disabled')) { customSelectSpan.addClass('customSelectDisabledOption'); }
+                        else { customSelectSpan.removeClass('customSelectDisabledOption'); }                        
                     }, 60);
                 };
 

--- a/jquery.customSelect.js
+++ b/jquery.customSelect.js
@@ -24,12 +24,16 @@
                     html = currentSelected.html() || '&nbsp;';
 
                     customSelectSpanInner.html(html);
-
+                    
+                    if (currentSelected.attr('disabled')) {
+                    	customSelectSpan.addClass('customSelectDisabledOption');
+                    } else {
+                    	customSelectSpan.removeClass('customSelectDisabledOption');
+                    }
+                    
                     setTimeout(function () {
                         customSelectSpan.removeClass('customSelectOpen');
-                        $(document).off('mouseup.customSelectOpen');
-                        if (currentSelected.attr('disabled')) { customSelectSpan.addClass('customSelectDisabledOption'); }
-                        else { customSelectSpan.removeClass('customSelectDisabledOption'); }                        
+                        $(document).off('mouseup.customSelectOpen');                  
                     }, 60);
                 };
 


### PR DESCRIPTION
the timeout is just to avoid mouse event handling conflicts when changing the `customSelectOpen` class. To avoid any confusion down the road, I've moved the `customSelectDisabledOption` class change outside since it doesn't need any delay anyways. Also Some minor code reformatting.
