### PR TITLE
customSelect with caption inside the select

### DIFF
--- a/jquery.customSelect.js
+++ b/jquery.customSelect.js
@@ -8,145 +8,160 @@
  * @license http://www.gnu.org/licenses/gpl.html GPL2 License 
  */
 
-(function ($) {
-    'use strict';
+(function ($)
+{
+   'use strict';
 
-    $.fn.extend({
-        customSelect: function (options) {
-            // filter out <= IE6
-            if (typeof document.body.style.maxHeight === 'undefined') {
-                return this;
+   $.fn.extend({
+      customSelect: function (options)
+      {
+         // filter out <= IE6
+         if (typeof document.body.style.maxHeight === 'undefined') {
+            return this;
+         }
+         var defaults = {
+            customClass: 'customSelect',
+            mapClass:     true,
+            mapStyle:     true
+         },
+         options = $.extend(defaults, options),
+         prefix = options.customClass,
+         changed = function ($select, customSelectSpan, caption) {
+            var currentSelected = $select.find(':selected'),
+            customSelectSpanInner = customSelectSpan.children(':first'),
+            html = currentSelected.html();
+
+            if (!html) {
+               html = caption;
+               customSelectSpan.addClass('caption');
+            } else {
+               customSelectSpan.removeClass('caption');
             }
-            var defaults = {
-                    customClass: 'customSelect',
-                    mapClass:    true,
-                    mapStyle:    true
-            },
-            options = $.extend(defaults, options),
-            prefix = options.customClass,
-            changed = function ($select,customSelectSpan) {
-                var currentSelected = $select.find(':selected'),
-                customSelectSpanInner = customSelectSpan.children(':first'),
-                html = currentSelected.html() || '&nbsp;';
+            customSelectSpanInner.html(html);
 
-                customSelectSpanInner.html(html);
-                
-                if (currentSelected.attr('disabled')) {
-                	customSelectSpan.addClass(getClass('DisabledOption'));
-                } else {
-                	customSelectSpan.removeClass(getClass('DisabledOption'));
-                }
-                
-                setTimeout(function () {
-                    customSelectSpan.removeClass(getClass('Open'));
-                    $(document).off('mouseup.'+getClass('Open'));                  
-                }, 60);
-            },
-            getClass = function(suffix){
-                return prefix + suffix;
-            };
+            if (currentSelected.attr('disabled')) {
+               customSelectSpan.addClass(getClass('DisabledOption'));
+            } else {
+               customSelectSpan.removeClass(getClass('DisabledOption'));
+            }
 
-            return this.each(function () {
-                var $select = $(this),
-                    customSelectInnerSpan = $('<span />').addClass(getClass('Inner')),
-                    customSelectSpan = $('<span />');
+            setTimeout(function () {
+               customSelectSpan.removeClass(getClass('Open'));
+               $(document).off('mouseup.' + getClass('Open'));
+            }, 60);
+         },
+         getClass = function (suffix)
+         {
+            return prefix + suffix;
+         };
 
-                $select.after(customSelectSpan.append(customSelectInnerSpan));
-                
-                customSelectSpan.addClass(prefix);
+         return this.each(function () {
+            var $select = $(this),
+                customSelectInnerSpan = $('<span />').addClass(getClass('Inner')),
+                customSelectSpan = $('<span />'),
+                caption = options.getCaption ? options.getCaption($select) : '&nbsp;';
 
-                if (options.mapClass) {
-                    customSelectSpan.addClass($select.attr('class'));
-                }
-                if (options.mapStyle) {
-                    customSelectSpan.attr('style', $select.attr('style'));
-                }
+            $select.after(customSelectSpan.append(customSelectInnerSpan));
 
-                $select
-                    .addClass('hasCustomSelect')
-                    .on('update', function () {
-						changed($select,customSelectSpan);
-						
-                        var selectBoxWidth = parseInt($select.outerWidth(), 10) -
-                                (parseInt(customSelectSpan.outerWidth(), 10) -
-                                    parseInt(customSelectSpan.width(), 10));
-						
-						// Set to inline-block before calculating outerHeight
-						customSelectSpan.css({
-                            display: 'inline-block'
+            customSelectSpan.addClass(prefix);
+
+            if (options.mapClass) {
+               customSelectSpan.addClass($select.attr('class'));
+            }
+            if (options.mapStyle) {
+               customSelectSpan.attr('style', $select.attr('style'));
+            }
+
+            $select
+               .addClass('hasCustomSelect')
+               .on('update', function () {
+                  changed($select, customSelectSpan, caption);
+
+                  $select.prepend($("<option/>").text(caption));
+
+                  var selectBoxWidth = parseInt($select.outerWidth(), 10) -
+                          (parseInt(customSelectSpan.outerWidth(), 10) -
+                              parseInt(customSelectSpan.width(), 10));
+
+                  $select.find(":first").remove();
+
+                  // Set to inline-block before calculating outerHeight
+                  customSelectSpan.css({
+                     display: 'inline-block'
+                  });
+
+                  var selectBoxHeight = customSelectSpan.outerHeight();
+
+                  if ($select.attr('disabled')) {
+                     customSelectSpan.addClass(getClass('Disabled'));
+                  } else {
+                     customSelectSpan.removeClass(getClass('Disabled'));
+                  }
+
+                  customSelectInnerSpan.css({
+                     width: selectBoxWidth,
+                     display: 'inline-block'
+                  });
+
+                  $select.css({
+                     '-webkit-appearance': 'menulist-button',
+                     width: customSelectSpan.outerWidth(),
+                     position: 'absolute',
+                     opacity: 0,
+                     height: selectBoxHeight,
+                     fontSize: customSelectSpan.css('font-size')
+                  });
+               })
+               .on('change', function () {
+                  customSelectSpan.addClass(getClass('Changed'));
+                  changed($select, customSelectSpan, caption);
+               })
+               .on('keyup', function (e) {
+                  if (!customSelectSpan.hasClass(getClass('Open'))) {
+                     $select.blur();
+                     $select.focus();
+                  } else {
+                     if (e.which == 13 || e.which == 27) {
+                        changed($select, customSelectSpan, caption);
+                     }
+                  }
+               })
+               .on('mousedown', function (e) {
+                  customSelectSpan.removeClass(getClass('Changed'));
+               })
+               .on('mouseup', function (e) {
+
+                  if (!customSelectSpan.hasClass(getClass('Open')))
+                  {
+                     // if FF and there are other selects open, just apply focus
+                     if ($('.' + getClass('Open')).not(customSelectSpan).length > 0 && typeof InstallTrigger !== 'undefined') {
+                        $select.focus();
+                     } else {
+                        customSelectSpan.addClass(getClass('Open'));
+                        e.stopPropagation();
+                        $(document).one('mouseup.' + getClass('Open'), function (e) {
+                           if (e.target != $select.get(0) && $.inArray(e.target, $select.find('*').get()) < 0) {
+                              $select.blur();
+                           } else {
+                              changed($select, customSelectSpan, caption);
+                           }
                         });
-						
-                        var selectBoxHeight = customSelectSpan.outerHeight();
-
-                        if ($select.attr('disabled')) {
-                            customSelectSpan.addClass(getClass('Disabled'));
-                        } else {
-                            customSelectSpan.removeClass(getClass('Disabled'));
-                        }
-
-                        customSelectInnerSpan.css({
-                            width:   selectBoxWidth,
-                            display: 'inline-block'
-                        });
-
-                        $select.css({
-                            '-webkit-appearance': 'menulist-button',
-                            width:                customSelectSpan.outerWidth(),
-                            position:             'absolute',
-                            opacity:              0,
-                            height:               selectBoxHeight,
-                            fontSize:             customSelectSpan.css('font-size')
-                        });
-                    })
-                    .on('change', function () {
-                        customSelectSpan.addClass(getClass('Changed'));
-                        changed($select,customSelectSpan);
-                    })
-                    .on('keyup', function (e) {
-                        if(!customSelectSpan.hasClass(getClass('Open'))){
-                            $select.blur();
-                            $select.focus();
-                        }else{
-                            if(e.which==13||e.which==27){
-                                changed($select,customSelectSpan);
-                            }
-                        }
-                    })
-                    .on('mousedown', function (e) {
-                        customSelectSpan.removeClass(getClass('Changed'));
-                    })
-                    .on('mouseup', function (e) {
-                        
-                        if( !customSelectSpan.hasClass(getClass('Open'))){
-                            // if FF and there are other selects open, just apply focus
-                            if($('.'+getClass('Open')).not(customSelectSpan).length>0 && typeof InstallTrigger !== 'undefined'){
-                                $select.focus();
-                            }else{
-                                customSelectSpan.addClass(getClass('Open'));
-                                e.stopPropagation();
-                                $(document).one('mouseup.'+getClass('Open'), function (e) {
-                                    if( e.target != $select.get(0) && $.inArray(e.target,$select.find('*').get()) < 0 ){
-                                        $select.blur();
-                                    }else{
-                                        changed($select,customSelectSpan);
-                                    }
-                                });
-                            }
-                        }
-                    })
-                    .focus(function () {
-                        customSelectSpan.removeClass(getClass('Changed')).addClass(getClass('Focus'));
-                    })
-                    .blur(function () {
-                        customSelectSpan.removeClass(getClass('Focus')+' '+getClass('Open'));
-                    })
-                    .hover(function () {
-                        customSelectSpan.addClass(getClass('Hover'));
-                    }, function () {
-                        customSelectSpan.removeClass(getClass('Hover'));
-                    })
-                    .trigger('update');
-            });
-        }
-    });
+                     }
+                  }
+               })
+               .focus(function () {
+                  customSelectSpan.removeClass(getClass('Changed')).addClass(getClass('Focus'));
+               })
+               .blur(function () {
+                  customSelectSpan.removeClass(getClass('Focus') + ' ' + getClass('Open'));
+               })
+               .hover(function () {
+                  customSelectSpan.addClass(getClass('Hover'));
+               }, function () {
+                  customSelectSpan.removeClass(getClass('Hover'));
+               })
+               .trigger('update');
+         });
+      }
+   });
 })(jQuery);


### PR DESCRIPTION
Hi Adam, 

I would like the possibility to have an empty option with no value, but still be able to provide a caption for the select, within the select itself. For instance, I would like the word 'Country' inside the select, but I don't want the first option of the select containing that word. I think that would be confusing for the end user.

With my proposed change, calling '$(selector).customSelect({getCaption: [func]})' the custom select will call that [func] function to get its caption and use that instead of the '&nbsp;' character for the empty option. On line 77 I create a new option with the caption for the control, before measuring the width, solely to get the right width for the 'span' elements. After the measurement I remove it again (line 83). In line 34 through 39, I add or remove the 'caption' class, to make it possible to style the selects differently when nothing was selected yet.

I hope you will consider my changes for release. Feel free to change my code in any way (Maybe it's already possible?).

I'd love to hear from you,

Erwin Keuning
Netherlands
